### PR TITLE
Add additional logic for deeply nested forms

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -195,9 +195,9 @@ class NewsItemsController < ApplicationController
       return unless content_block_params.present?
 
       content_blocks = []
-      media_contents = []
       content_block_params.each do |key, content_block|
         next if content_block.blank?
+        media_contents = []
         content_block[:media_contents].each do |key, media_content|
           media_contents << media_content
         end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -21,30 +21,32 @@ require('@kanety/jquery-nested-form');
 // const images = require.context('../images', true)
 // const imagePath = (name) => images(name, true)
 
+const initClassicEditor = (htmlEditor) => {
+  ClassicEditor.create(htmlEditor, {
+    toolbar: [
+      'heading',
+      '|',
+      'bulletedList',
+      'numberedList',
+      'link',
+      'bold',
+      'italic',
+      '|',
+      'undo',
+      'redo'
+    ]
+  })
+    .then((editor) => {
+      // console.log(Array.from(editor.ui.componentFactory.names()));
+    })
+    .catch((error) => {
+      console.error(error);
+    });
+};
+
 /* eslint-disable func-names */
 $(function() {
-  document.querySelectorAll('.html-editor').forEach((htmlEditor) =>
-    ClassicEditor.create(htmlEditor, {
-      toolbar: [
-        'heading',
-        '|',
-        'bulletedList',
-        'numberedList',
-        'link',
-        'bold',
-        'italic',
-        '|',
-        'undo',
-        'redo'
-      ]
-    })
-      .then((editor) => {
-        // console.log(Array.from(editor.ui.componentFactory.names()));
-      })
-      .catch((error) => {
-        console.error(error);
-      })
-  );
+  document.querySelectorAll('.html-editor').forEach((htmlEditor) => initClassicEditor(htmlEditor));
 
   const defaultNestedFormsOptions = {
     remover: '.remove',
@@ -125,6 +127,12 @@ $(function() {
       },
       afterAddForm: function($container, $form) {
         initNestedMediaContents($form);
+
+        // init html editors for content block fields body and intro
+        $form
+          .get('0')
+          .querySelectorAll('.html-editor')
+          .forEach((htmlEditor) => initClassicEditor(htmlEditor));
       }
     });
   }

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -79,7 +79,7 @@ $(function() {
     associations: 'urls' // needed to correctly increment ids of added sections
   });
 
-  // media not nested in a content block, for example in events
+  // media not nested in a content block, for example in events.
   // everything with classes here, because in content blocks nested-media will appear multiple times
   $('.nested-media').nestedForm({
     forms: '.nested-medium-form',
@@ -87,49 +87,47 @@ $(function() {
     ...defaultNestedFormsOptions
   });
 
-  // initial rendered media nested in a content block, for example in news
-  // this is commented out to make the afterAddForm logic work in content blocks for additionally
-  // added sections
-  // $('.nested-media-content-block').nestedForm({
-  //   forms: '.nested-medium-form',
-  //   adder: '.nested-add-medium',
-  //   remover: '.remove',
-  //   postfixes: ''
-  // });
-
-  $('#nested-content-blocks').nestedForm({
-    forms: '.nested-content-block-form',
-    adder: '#nested-add-content-block',
-    remover: '.removeContent',
-    postfixes: '',
-    afterAddForm: function($container, $form) {
-      console.log('afterAddForm: .nested-content-block-form', $container, $form);
-
+  if ($('#nested-content-blocks').length) {
+    const initNestedMediaContents = ($form) => {
       const timestamp = Date.now();
 
-      // this only works, if $('.nested-media-content-block').nestedForm({... is commented out
-      // but then initially rendered content blocks are not working
-      $form
-        .find('.nested-media-content-block')
-        .addClass('nested-media-content-block-' + timestamp)
-        .removeClass('nested-media-content-block');
-      $form
-        .find('.nested-add-medium')
-        .addClass('nested-add-medium-' + timestamp)
-        .removeClass('nested-add-medium');
-      $form
-        .find('.nested-medium-form')
-        .addClass('nested-medium-form-' + timestamp)
-        .removeClass('nested-medium-form');
+      $form.find('.nested-media-content-block').addClass(`nested-media-content-block-${timestamp}`);
+      $form.find('.nested-medium-form').addClass(`nested-medium-form-${timestamp}`);
+      $form.find('.nested-add-medium').addClass(`nested-add-medium-${timestamp}`);
 
-      $form.find('.nested-media-content-block-' + timestamp).nestedForm({
-        forms: '.nested-medium-form-' + timestamp,
-        adder: '.nested-add-medium-' + timestamp,
-        remover: '.remove',
-        postfixes: ''
+      $form.find(`.nested-media-content-block-${timestamp}`).nestedForm({
+        forms: `.nested-medium-form-${timestamp}`,
+        adder: `.nested-add-medium-${timestamp}`,
+        ...defaultNestedFormsOptions,
+        associations: 'media_contents' // needed to correctly increment ids of added sections
       });
-    }
-  });
+    };
+
+    $('#nested-content-blocks').nestedForm({
+      forms: '.nested-content-block-form',
+      adder: '#nested-add-content-block',
+      remover: '.removeContent',
+      postfixes: '',
+      afterInitialize: function() {
+        const $initialForms = $('.nested-content-block-form');
+
+        $initialForms.each((index, form) => {
+          initNestedMediaContents($(form));
+        });
+      },
+      beforeAddForm: function($container, $form) {
+        // we only want one initialized media content, so remove eventually created others
+        $form.find('.nested-medium-form').each((index, form) => {
+          if (index > 0) {
+            $(form).remove();
+          }
+        });
+      },
+      afterAddForm: function($container, $form) {
+        initNestedMediaContents($form);
+      }
+    });
+  }
 
   // Init DataTables for all tables with css-class 'data_table'
   $.fn.dataTable = DataTable;

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -79,6 +79,7 @@ $(function() {
     associations: 'urls' // needed to correctly increment ids of added sections
   });
 
+  // media not nested in a content block, for example in events
   // everything with classes here, because in content blocks nested-media will appear multiple times
   $('.nested-media').nestedForm({
     forms: '.nested-medium-form',
@@ -86,11 +87,48 @@ $(function() {
     ...defaultNestedFormsOptions
   });
 
+  // initial rendered media nested in a content block, for example in news
+  // this is commented out to make the afterAddForm logic work in content blocks for additionally
+  // added sections
+  // $('.nested-media-content-block').nestedForm({
+  //   forms: '.nested-medium-form',
+  //   adder: '.nested-add-medium',
+  //   remover: '.remove',
+  //   postfixes: ''
+  // });
+
   $('#nested-content-blocks').nestedForm({
     forms: '.nested-content-block-form',
     adder: '#nested-add-content-block',
     remover: '.removeContent',
-    postfixes: ''
+    postfixes: '',
+    afterAddForm: function($container, $form) {
+      console.log('afterAddForm: .nested-content-block-form', $container, $form);
+
+      const timestamp = Date.now();
+
+      // this only works, if $('.nested-media-content-block').nestedForm({... is commented out
+      // but then initially rendered content blocks are not working
+      $form
+        .find('.nested-media-content-block')
+        .addClass('nested-media-content-block-' + timestamp)
+        .removeClass('nested-media-content-block');
+      $form
+        .find('.nested-add-medium')
+        .addClass('nested-add-medium-' + timestamp)
+        .removeClass('nested-add-medium');
+      $form
+        .find('.nested-medium-form')
+        .addClass('nested-medium-form-' + timestamp)
+        .removeClass('nested-medium-form');
+
+      $form.find('.nested-media-content-block-' + timestamp).nestedForm({
+        forms: '.nested-medium-form-' + timestamp,
+        adder: '.nested-add-medium-' + timestamp,
+        remover: '.remove',
+        postfixes: ''
+      });
+    }
   });
 
   // Init DataTables for all tables with css-class 'data_table'

--- a/app/views/news_items/form_partials/_content_blocks_form.html.erb
+++ b/app/views/news_items/form_partials/_content_blocks_form.html.erb
@@ -46,7 +46,14 @@
               Bereich werden als Slider/Karussell dargestellt.
             </p>
 
-            <%= render partial: "shared/partials/media_contents_form", locals: { record: content_block, form: fcb } %>
+            <%= render(
+                  partial: "shared/partials/media_contents_form",
+                  locals: {
+                    record: content_block,
+                    form: fcb,
+                    form_class: "nested-media-content-block"
+                  }
+                ) %>
           </div>
         </div>
       </div>

--- a/app/views/shared/partials/_media_contents_form.html.erb
+++ b/app/views/shared/partials/_media_contents_form.html.erb
@@ -1,7 +1,8 @@
+<% form_class ||= "nested-media" %>
 <% list_of_media_contents = record.media_contents.presence || [OpenStruct.new] %>
 
 <!-- TODO: Dateien entfernen und ergänzen geht nur im ersten Bereich!!! -->
-<div class="nested-media">
+<div class="<%= form_class %>">
   <% list_of_media_contents.each_with_index do |media_content, index| %>
     <%= form.fields_for "media_contents[#{index}]", media_content do |fmc| %>
       <div class="nested-medium-form">


### PR DESCRIPTION
- we need more logic after adding a block of contents
  to make the inner logic work
- the https://github.com/kanety/jquery-nested-form is providing
  events, which we can use
- added a new class for nested media if rendered within
  content block
  - otherwise default still "nested-media"
- started working on new js logic for the new class to be able
  to make deeply nested forms work