### PR TITLE
Avoid empty objects and add opening hours form

### DIFF
--- a/app/controllers/point_of_interests_controller.rb
+++ b/app/controllers/point_of_interests_controller.rb
@@ -68,6 +68,15 @@ class PointOfInterestsController < ApplicationController
               longitude
             }
           }
+          openingHours {
+            weekday
+            timeFrom
+            timeTo
+            open
+            dateFrom
+            dateTo
+            description
+          }
           contact {
             id
             email
@@ -262,6 +271,17 @@ class PointOfInterestsController < ApplicationController
         end
       end
 
+      # Convert has_many opening_hours
+      if @point_of_interest_params["opening_hours"].present?
+        opening_hours = []
+        @point_of_interest_params["opening_hours"].each do |_key, opening_hour|
+          next if opening_hour.blank?
+
+          opening_hours << opening_hour if nested_values?(opening_hour.to_h).include?(true)
+        end
+        @point_of_interest_params["opening_hours"] = opening_hours
+      end
+
       # Convert has_many categories
       if @point_of_interest_params["categories"].present?
         categories = []
@@ -291,9 +311,7 @@ class PointOfInterestsController < ApplicationController
         @point_of_interest_params["media_contents"].each do |_key, media_content|
           next if media_content.blank?
 
-          if media_content.dig("source_url", "url").present?
-            media_contents << media_content
-          end
+          media_contents << media_content if media_content.dig("source_url", "url").present?
         end
         @point_of_interest_params["media_contents"] = media_contents
       end

--- a/app/javascript/partials/_nested_forms.js
+++ b/app/javascript/partials/_nested_forms.js
@@ -39,6 +39,12 @@ $(function() {
     associations: 'urls' // needed to correctly increment ids of added sections
   });
 
+  $('#nested-opening-hours').nestedForm({
+    forms: '.nested-opening-hour-form',
+    adder: '#nested-add-opening-hour',
+    ...defaultNestedFormsOptions
+  });
+
   // media not nested in a content block, for example in events.
   // everything with classes here, because in content blocks nested-media will appear multiple times
   $('.nested-media').nestedForm({

--- a/app/views/point_of_interests/_form.html.erb
+++ b/app/views/point_of_interests/_form.html.erb
@@ -47,10 +47,9 @@
     </div>
   </div>
 
-  <% point_of_interest.addresses.each do |address| %>
-    <%= f.fields_for :addresses, address do |fadd|  %>
-      <%= render partial: "shared/partials/address_form", locals: { form: fadd, address: address } %>
-    <% end %>
+  <% address = point_of_interest.try(:addresses).try(:first) || OpenStruct.new(geo_location: nil) %>
+  <%= f.fields_for :addresses, address do |fadd| %>
+    <%= render partial: "shared/partials/address_form", locals: { form: fadd, address: address } %>
   <% end %>
 
   <hr />
@@ -75,8 +74,9 @@
     </div>
   </div>
 
-  <%= f.fields_for "contact", point_of_interest.contact do |fc|  %>
-    <%= render partial: "shared/partials/contact_form", locals: { form: fc, contact: point_of_interest.contact } %>
+  <% contact = point_of_interest.try(:contact) || OpenStruct.new(web_urls: [OpenStruct.new]) %>
+  <%= f.fields_for "contact", contact do |fc|  %>
+    <%= render partial: "shared/partials/contact_form", locals: { form: fc, contact: contact } %>
   <% end %>
 
   <%= render partial: "shared/partials/web_url_form", locals: { record: point_of_interest, record_type: "point_of_interest", form: f } %>

--- a/app/views/point_of_interests/_form.html.erb
+++ b/app/views/point_of_interests/_form.html.erb
@@ -54,6 +54,8 @@
 
   <hr />
 
+  <%= render partial: "shared/partials/opening_hours_form", locals: { record: point_of_interest, record_type: "point_of_interest", form: f } %>
+
   <div class="row">
     <div class="col">
       <h3 class="d-sm-flex align-items-center justify-content-between my-4">

--- a/app/views/shared/partials/_opening_hours_form.html.erb
+++ b/app/views/shared/partials/_opening_hours_form.html.erb
@@ -1,0 +1,110 @@
+<div class="row">
+  <div class="col">
+    <h3 class="d-sm-flex align-items-center justify-content-between my-4">
+      Öffnungszeiten
+    </h3>
+  </div>
+</div>
+
+<% list_of_opening_hours = record.opening_hours.presence || [OpenStruct.new] %>
+
+<div id="nested-opening-hours">
+  <% list_of_opening_hours.each_with_index do |opening_hour, index| %>
+    <%= fields_for "#{record_type}[opening_hours][#{index}]", opening_hour do |foh|  %>
+      <div class="nested-opening-hour-form">
+        <div class="card mb-4">
+          <div class="card-header py-3 bg-dark text-white">
+            <h4 class="m-0 d-sm-flex align-items-center justify-content-between float-left">
+              Öffnungszeit
+            </h4>
+            <input
+              type="button"
+              value="diese Öffnungszeit entfernen"
+              class="float-right remove btn btn-sm btn-danger"
+            />
+          </div>
+          <div class="card-body">
+            <div class="row">
+              <div class="col-lg-6">
+                <div class="form-group">
+                  <label for="date_from">Startdatum *</label>
+                  <%= foh.date_field :date_from, class: "form-control", value: foh.object.date_from %>
+                </div>
+              </div>
+              <div class="col-lg-6">
+                <div class="form-group">
+                  <label for="date_to">Enddatum</label>
+                  <%= foh.date_field :date_to, class: "form-control", value: foh.object.date_to %>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-12 col-sm-6">
+                <div class="form-group">
+                  <label for="time_from">Startzeit *</label>
+                  <%= foh.time_field :time_from, class: "form-control", value: foh.object.time_from %>
+                </div>
+              </div>
+              <div class="col-12 col-sm-6">
+                <div class="form-group">
+                  <label for="time_to">Endzeit</label>
+                  <%= foh.time_field :time_to, class: "form-control", value: foh.object.time_to %>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-12 col-sm-6">
+                <div class="form-group">
+                  <label for="description">Beschreibung</label>
+                  <%= foh.text_field :description, class: "form-control" %>
+                </div>
+              </div>
+              <div class="col-12 col-sm-6">
+                <div class="form-group">
+                  <label for="weekday">Wochentag</label>
+                  <%= foh.select(
+                        :weekday,
+                        options_for_select(
+                          [
+                            "Montag",
+                            "Dienstag",
+                            "Mittwoch",
+                            "Donnerstag",
+                            "Freitag",
+                            "Samstag",
+                            "Sonntag"
+                          ],
+                          foh.object.weekday
+                        ),
+                        { include_blank: true },
+                        { class: "form-control"  }
+                      ) %>
+                </div>
+              </div>
+            </div>
+
+            <div class="row">
+              <div class="col-12 col-sm-6">
+                <div class="form-group">
+                  <%= foh.check_box :open, { }, true, false %>
+                  <%= foh.label :open, "geöffnet?" %>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    <% end %>
+  <% end %>
+</div>
+
+<input
+  type="button"
+  value="weitere Öffnungszeit hinzufügen"
+  id="nested-add-opening-hour"
+  class="btn btn-sm btn-secondary"
+/>
+
+<hr />


### PR DESCRIPTION
feat(edit point of interest): avoid empty objects to be transmitted

- added deeper checks for presence of the following data:
  - addresses
  - contact
  - mediaContents
  - price_informations
  - lunches
- adjusted two form renderings to render empty fields if there are no initial data
- if the server does not get certain attributes, there will be none of them created without further empty attributes

feat(edit point of interest): add opening hours form

SVA-183
Fixes #42
Fixes #43
Fixes #44