### PR TITLE
feat(sidebar): position over content

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -41,12 +41,33 @@ body.app {
   color: #11223f;
 }
 
+@media (min-width: 768px) {
+  body.app {
+    margin-left: 104px; /* NOTE: necessary because of the sidebar */
+  }
+}
+
+@media (max-width: 768px) {
+  #sidebarToggleTop {
+    margin-left: 104px; /* NOTE: necessary because of the sidebar */
+  }
+
+  #sidebarToggleTop.toggled {
+    margin-left: 0; /* NOTE: necessary because of the sidebar */
+  }
+}
+
 body .table {
   color: #11223f;
 }
 
 body .navbar-nav.sidebar {
   background-color: #11223f;
+  bottom: 0;
+  left: 0;
+  position: absolute;
+  top: 0;
+  z-index: 2;
 }
 
 body .btn-primary {

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -81,25 +81,20 @@ $(function() {
   });
 
   // Toggle the side navigation
-  $('#sidebarToggle, #sidebarToggleTop').on('click', function(e) {
-    $('.sidebar').toggleClass('toggled');
+  $('#sidebarToggle, #sidebarToggleTop').on('click', function() {
+    $('.sidebar, #sidebarToggleTop').toggleClass('toggled');
   });
-
-  // On small screens don't show sidebar on load
-  if ($(window).width() < 768) {
-    $('.sidebar').toggleClass('toggled');
-  }
 
   // Close any open menu accordions when window is resized below 768px
   $(window).resize(function() {
-    if ($(window).width() < 768) {
-      $('.sidebar').addClass('toggled');
+    if ($(window).width() < 992) {
+      $('.sidebar, #sidebarToggleTop').addClass('toggled');
     }
   });
 
   // Prevent the content wrapper from scrolling when the fixed side navigation hovered over
   $('body.fixed-nav .sidebar').on('mousewheel DOMMouseScroll wheel', function(e) {
-    if ($(window).width() > 768) {
+    if ($(window).width() > 991) {
       var e0 = e.originalEvent,
         delta = e0.wheelDelta || -e0.detail;
       this.scrollTop += (delta < 0 ? 1 : -1) * 30;

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -24,7 +24,7 @@
 
       <% if @current_user.present? %>
         <!-- Sidebar -->
-        <ul class="navbar-nav sidebar sidebar-dark accordion" id="accordionSidebar">
+        <ul class="navbar-nav sidebar sidebar-dark accordion toggled" id="accordionSidebar">
 
           <!-- Sidebar - Brand -->
           <a class="sidebar-brand d-flex " href="/">
@@ -59,7 +59,7 @@
             <nav class="navbar navbar-expand navbar-light bg-white topbar mb-4 static-top shadow">
 
               <!-- Sidebar Toggle (Topbar) -->
-              <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3">
+              <button id="sidebarToggleTop" class="btn btn-link d-md-none rounded-circle mr-3 toggled">
                 <i class="fa fa-bars"></i>
               </button>
 


### PR DESCRIPTION
- this places the sidebar over the page content
- it always renders initially in toggled mode now to not cover page contents
- the page itself needs to move the width of the toggled sidebar to the left, so that contents are not covered
- therefore on mobile the top toggler needs to move as well if the sidebar is opened

SVA-206

---

please play around to see if it feels ok in several places

### Screenshots

![Bildschirmfoto 2021-06-10 um 17 50 40](https://user-images.githubusercontent.com/1942953/121556777-77067280-ca14-11eb-99de-244c790e492a.png)
![Bildschirmfoto 2021-06-10 um 17 50 46](https://user-images.githubusercontent.com/1942953/121556782-78379f80-ca14-11eb-8118-21286f126c67.png)
![Bildschirmfoto 2021-06-10 um 17 50 58](https://user-images.githubusercontent.com/1942953/121556786-78d03600-ca14-11eb-85e1-ae7d59b4eedf.png)
![Bildschirmfoto 2021-06-10 um 17 51 03](https://user-images.githubusercontent.com/1942953/121556788-7968cc80-ca14-11eb-9466-6f6033ba63af.png)
![Bildschirmfoto 2021-06-10 um 17 51 11](https://user-images.githubusercontent.com/1942953/121556793-7a016300-ca14-11eb-9f0d-1f8b91ff0f07.png)
![Bildschirmfoto 2021-06-10 um 17 59 22](https://user-images.githubusercontent.com/1942953/121558064-9a7ded00-ca15-11eb-847d-c8d055845bf5.png)