### PR TITLE
CMS Sprachen aus Mainserver

### DIFF
--- a/app/controllers/surveys_controller.rb
+++ b/app/controllers/surveys_controller.rb
@@ -3,6 +3,7 @@
 class SurveysController < ApplicationController
   before_action :verify_current_user
   before_action :init_graphql_client
+  before_action :load_languages, only: [:index, :new, :edit]
 
   def index
     results = @smart_village.query <<~GRAPHQL
@@ -85,6 +86,17 @@ class SurveysController < ApplicationController
   end
 
   private
+
+    def load_languages
+      languages = @smart_village.query <<~GRAPHQL
+      query {
+        publicJsonFile(name: "languages") {
+          content
+        }
+      }
+      GRAPHQL
+      @languages = JSON.parse(languages.data.public_json_file.content)
+    end
 
     def new_survey_record
       OpenStruct.new(

--- a/app/views/surveys/_form.html.erb
+++ b/app/views/surveys/_form.html.erb
@@ -2,41 +2,35 @@
   <%= f.hidden_field :id, name: "survey[id]" %>
   <div class="row">
     <div class="col">
-      <div class="form-group">
-        <label for="description">Titel (deutsch)</label>
-        <%= f.text_field :title_de, name: "survey[title][de]", class: "form-control" %>
-      </div>
-      <div class="form-group">
-        <label for="description">Titel (polnisch)</label>
-        <%= f.text_field :title_pl, name: "survey[title][pl]", class: "form-control" %>
-      </div>
+      <% @languages.each do |language| %>
+        <div class="form-group">
+          <label for="description">Titel (<%= language %>)</label>
+          <%= f.text_field "title_#{language}", name: "survey[title][#{language}]", class: "form-control" %>
+        </div>
+      <% end %>
     </div>
   </div>
 
   <div class="row">
     <div class="col">
-      <div class="form-group">
-        <label for="description">Beschreibung (deutsch)</label>
-        <%= f.text_area :description_de, name: "survey[description][de]", class: "form-control", rows: 3 %>
-      </div>
-      <div class="form-group">
-        <label for="description">Beschreibung (polnisch)</label>
-        <%= f.text_area :description_pl, name: "survey[description][pl]", class: "form-control", rows: 3 %>
-      </div>
+      <% @languages.each do |language| %>
+        <div class="form-group">
+          <label for="description">Beschreibung (<%= language %>)</label>
+          <%= f.text_area "description_#{language}", name: "survey[description][#{language}]", class: "form-control", rows: 3 %>
+        </div>
+      <% end %>
     </div>
   </div>
 
   <div class="row">
     <%= f.hidden_field :question_id, name: "survey[question_id]" %>
     <div class="col">
-      <div class="form-group">
-        <label for="description">Frage (deutsch) *</label>
-        <%= f.text_field :question_title_de, name: "survey[question_title][de]", class: "form-control", required: true %>
-      </div>
-      <div class="form-group">
-        <label for="description">Frage (polnisch)</label>
-        <%= f.text_field :question_title_pl, name: "survey[question_title][pl]", class: "form-control" %>
-      </div>
+      <% @languages.each do |language| %>
+        <div class="form-group">
+          <label for="description">Frage (<%= language %>) *</label>
+          <%= f.text_field "question_title_#{language}", name: "survey[question_title][#{language}]", class: "form-control", required: true %>
+        </div>
+      <% end %>
     </div>
   </div>
 
@@ -68,7 +62,7 @@
         Stimmen abgegeben wurden.
       </p>
 
-      <p><small>(min. 2, max. 10, Zeichenlänge max. 150, in deutsch und polnisch)</small></p>
+      <p><small>(min. 2, max. 10, Zeichenlänge max. 150, in <%= @languages.join(" und ") %>)</small></p>
 
       <%= render partial: "surveys/form_partials/response_options_form", locals: { survey: survey, form: f  } %>
     </div>

--- a/app/views/surveys/form_partials/_response_options_form.html.erb
+++ b/app/views/surveys/form_partials/_response_options_form.html.erb
@@ -11,18 +11,14 @@
       <div class="nested-response-option-form">
         <%= fro.hidden_field :id, name: "survey[response_options][#{index}][id]" %>
         <div class="row">
-          <div class="col-12 col-sm-6">
-            <div class="form-group">
-              <label for="description"><%= index + 1 %>. Antwortmöglichkeit (deutsch)<%= " *" if [0, 1].include?(index) %></label>
-              <%= fro.text_field :title_de, name: "survey[response_options][#{index}][title][de]", class: "form-control", maxlength: "150", required: [0, 1].include?(index) %>
+          <% @languages.each_with_index do |language, language_index| %>
+            <div class="col-12 col-sm-6">
+              <div class="form-group">
+                <label for="description"><%= index + 1 %>. Antwortmöglichkeit (<%= language %>)<%= " *" if [0, 1].include?(index) && language_index == 0 %></label>
+                <%= fro.text_field "title_#{language}", name: "survey[response_options][#{index}][title][#{language}]", class: "form-control", maxlength: "150", required: [0, 1].include?(index) && language_index == 0 %>
+              </div>
             </div>
-          </div>
-          <div class="col-12 col-sm-6">
-            <div class="form-group">
-              <label for="description"><%= index + 1 %>. Antwortmöglichkeit (polnisch)</label>
-              <%= fro.text_field :title_pl, name: "survey[response_options][#{index}][title][pl]", class: "form-control", maxlength: "150" %>
-            </div>
-          </div>
+          <% end %>
         </div>
         <% if response_option.votes_count.present? %>
           <div class="row">

--- a/app/views/surveys/index.html.erb
+++ b/app/views/surveys/index.html.erb
@@ -29,7 +29,7 @@
           <td><%= toLocalDateTime(survey.updated_at) %></td>
           <td><%= toLocalDateTime(survey.created_at) %></td>
           <% if editor? %>
-            <td><%= survey.data_provider.name %></td>
+            <td><%= survey.data_provider.try(:name) %></td>
             <td align="center"><%= visibility_switch(survey, "Survey") %></td>
           <% end %>
           <td align="right" class="text-nowrap">


### PR DESCRIPTION
Das CMS verwendet bei den Umfragen nun die im MainServer hinterlegten Sprachen und keine fixen Werte.

Ticket?

---

@donni106 (_kann mich leider nicht selbst als reviewer festlegen_)