### PR TITLE
fix(date fields): force visibility for all date fields

### DIFF
--- a/app/views/constructions/_form.html.erb
+++ b/app/views/constructions/_form.html.erb
@@ -119,7 +119,8 @@
           values: {
             date_start: (Time.now).to_date,
             date_end: (Time.now).to_date
-          }
+          },
+          force_visibility: true
       }) %>
 
   <hr />

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -99,7 +99,8 @@
           },
           values: {
             date_end: (Time.now + 4.weeks).to_date
-          }
+          },
+          force_visibility: true
       }) %>
 
   <hr />

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -71,7 +71,8 @@
           },
           values: {
             date_end: (Time.now + 4.weeks).to_date
-          }
+          },
+          force_visibility: true
       }) %>
 
   <hr />

--- a/app/views/surveys/_form.html.erb
+++ b/app/views/surveys/_form.html.erb
@@ -53,7 +53,8 @@
         },
         values: {
           date_start: Time.now.to_date
-        }
+        },
+        force_visibility: true
     }) %>
 
   <div class="row">


### PR DESCRIPTION
- added `force_visibility: true` to the date fields which are empty because we want to show them always and there are no "add date" buttons to make them visible