### PR TITLE
feat(constructions): update form fields

### DIFF
--- a/app/controllers/constructions_controller.rb
+++ b/app/controllers/constructions_controller.rb
@@ -65,6 +65,7 @@ class ConstructionsController < ApplicationController
             dateEnd
           }
           locations {
+            name
             geoLocation {
               latitude
               longitude

--- a/app/views/constructions/_form.html.erb
+++ b/app/views/constructions/_form.html.erb
@@ -1,5 +1,5 @@
 <%= fields_for :construction, construction do |f| %>
-  <%= hidden_field_tag "construction[generic_type]", @construction.generic_type %>
+  <%= hidden_field_tag "construction[generic_type]", construction.generic_type %>
 
   <div class="row">
     <div class="col">
@@ -10,13 +10,17 @@
     </div>
   </div>
 
+  <% list_of_content_blocks = construction.content_blocks.presence || [OpenStruct.new] %>
   <div class="row">
     <div class="col">
-      <h2 class="d-sm-flex align-items-center justify-content-between my-4">
-        Inhalt
-      </h2>
-
-      <%= render partial: "shared/partials/content_blocks_form", locals: { record: construction, form: f, fields: ['body']  } %>
+      <div class="form-group">
+        <label for="description">Weitere Informationen</label>
+        <% list_of_content_blocks.each_with_index do |content_block, index| %>
+          <%= f.fields_for "content_blocks[#{index}]", content_block do |fcb| %>
+            <%= fcb.text_area :body, class: "form-control", rows: 10 %>
+          <% end %>
+        <% end %>
+      </div>
     </div>
   </div>
 
@@ -26,7 +30,7 @@
         <label for="description">Richtung</label>
         <%= text_field_tag(
               "construction_payload_direction",
-              (@construction.payload || {})["direction"],
+              (construction.payload || {})["direction"],
               placeholder: "Norden, Osten, Süden, Westen",
               class: "form-control",
               name: "construction[payload][direction]"
@@ -41,7 +45,7 @@
         <label for="description">Grund</label>
         <%= text_field_tag(
               "construction_payload_cause",
-              (@construction.payload || {})["cause"],
+              (construction.payload || {})["cause"],
               class: "form-control",
               name: "construction[payload][cause]"
             )%>
@@ -83,29 +87,36 @@
 
   <hr />
 
-  <div class="row">
-    <div class="col-lg-6">
-      <div class="form-group">
-        <label for="description">Latitude</label>
-        <% list_of_locations = construction.locations.presence || [OpenStruct.new(geo_location: nil)] %>
-        <% list_of_locations.each_with_index do |location, index| %>
-          <%= fields_for "construction[locations][#{index}][geo_location]", location.geo_location do |fl| %>
-            <%= fl.text_field :latitude, class: "form-control" %>
-          <% end %>
-        <% end %>
+  <% list_of_locations = construction.locations.presence || [OpenStruct.new(geo_location: nil)] %>
+  <% list_of_locations.each_with_index do |location, index| %>
+    <%= fields_for "construction[locations][#{index}]", location do |fl| %>
+      <div class="row">
+        <div class="col">
+          <div class="form-group">
+            <label for="description">Standort</label>
+            <%= fl.text_field :name, class: "form-control" %>
+          </div>
+        </div>
       </div>
-    </div>
+    <% end %>
 
-    <div class="col-lg-6">
-      <div class="form-group">
-        <label for="description">Longitude</label>
-        <% list_of_locations.each_with_index do |location, index| %>
-          <%= fields_for "construction[locations][#{index}][geo_location]", location.geo_location do |fl| %>
-            <%= fl.text_field :longitude, class: "form-control" %>
-          <% end %>
-        <% end %>
-      </div>
-    </div>
+    <%= fields_for "construction[locations][#{index}][geo_location]", location.geo_location do |fgl| %>
+      <div class="row">
+        <div class="col-lg-6">
+          <div class="form-group">
+            <label for="description">Latitude</label>
+            <%= fgl.text_field :latitude, class: "form-control" %>
+          </div>
+        </div>
+
+        <div class="col-lg-6">
+          <div class="form-group">
+            <label for="description">Longitude</label>
+            <%= fgl.text_field :longitude, class: "form-control" %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
   </div>
 
   <hr />

--- a/app/views/shared/partials/_restrictions_form.html.erb
+++ b/app/views/shared/partials/_restrictions_form.html.erb
@@ -1,5 +1,5 @@
 <% fields = ["description"] %>
-<% list_of_restrictions = (@construction.payload || {})["restrictions"].presence || [OpenStruct.new] %>
+<% list_of_restrictions = (record.payload || {})["restrictions"].presence || [OpenStruct.new] %>
 
 <div class="row">
   <div class="col">


### PR DESCRIPTION
- used a default text area for content block body instead of html
- added a location name to enter beside geo coordinates
- refactored form view to reduce a list of locations iteration
- refactored usages of global `@construction` in views to certain local variables

SVA-212

---

![Bildschirmfoto 2021-07-20 um 13 12 32](https://user-images.githubusercontent.com/1942953/126316631-4a438784-8592-4924-95c3-ac6f086d22af.png)
![Bildschirmfoto 2021-07-20 um 13 24 48](https://user-images.githubusercontent.com/1942953/126316636-045dfc57-8292-43c9-8924-8419134a26c9.png)
<img width="170" alt="Bildschirmfoto 2021-07-20 um 13 25 52" src="https://user-images.githubusercontent.com/1942953/126316638-5ca2606c-b268-4c7e-bde6-a1fea0b2a223.png">
