### PR TITLE
fix(lunch text): remove html ability of textarea

### DIFF
--- a/app/views/point_of_interests/form_partials/_lunches_form.html.erb
+++ b/app/views/point_of_interests/form_partials/_lunches_form.html.erb
@@ -30,7 +30,7 @@
                   <div class="col">
                     <div class="form-group">
                       <label for="text">Text</label>
-                      <%= fl.text_area :text, class: "form-control html-editor html-editor-text", rows: 10 %>
+                      <%= fl.text_area :text, class: "form-control", rows: 10 %>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
SVA-265

![Bildschirmfoto 2021-08-02 um 16 47 11](https://user-images.githubusercontent.com/1942953/127880264-df2445e7-0766-4d67-8874-2b7ccfecc605.png)

to avoid

![Bildschirmfoto 2021-08-02 um 16 36 04](https://user-images.githubusercontent.com/1942953/127880321-eba87d1a-25c8-4c1d-a5a9-481236974eb1.png)

which will not be rendered as html in the mobile app
