### PR TITLE
Prevent resize event from triggering

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -85,14 +85,31 @@ $(function() {
     $('.sidebar, #sidebarToggleTop').toggleClass('toggled');
   });
 
-  // Close any open menu accordions when window is resized below 768px
+  // Close any open menu accordions when window is resized below 992px.
   // Resize event gets triggered on mobile scroll as the address bar gets smaller,
-  // therefore check for difference in width inside resize event
+  // therefore check for difference in width inside resize event.
   var width = $(window).width();
-  $(window).resize(function() {
+
+  $(window).on('resize', function() {
     if ($(window).width() != width && $(window).width() < 992) {
       $('.sidebar, #sidebarToggleTop').addClass('toggled');
     }
+  });
+
+  // on rotation change remove resize listener, update `width` and bin resize listener again
+  $(window).on('orientationchange', function() {
+    $(window).off('resize');
+
+    // wait a bit until orientation is changed and new dimensions set
+    setTimeout(() => {
+      width = $(window).width();
+
+      $(window).on('resize', function() {
+        if ($(window).width() != width && $(window).width() < 992) {
+          $('.sidebar, #sidebarToggleTop').addClass('toggled');
+        }
+      });
+    }, 500);
   });
 
   // Prevent the content wrapper from scrolling when the fixed side navigation hovered over

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -86,8 +86,11 @@ $(function() {
   });
 
   // Close any open menu accordions when window is resized below 768px
+  // Resize event gets triggered on mobile scroll as the address bar gets smaller,
+  // therefore check for difference in width inside resize event
+  var width = $(window).width();
   $(window).resize(function() {
-    if ($(window).width() < 992) {
+    if ($(window).width() != width && $(window).width() < 992) {
       $('.sidebar, #sidebarToggleTop').addClass('toggled');
     }
   });


### PR DESCRIPTION
On mobile scroll the navbar dissappears, because the resize event gets triggered

- jquery event gets triggered on mobile scroll, as the address bar gets smaller in height
- therefore check for width difference at the resize event and only toggle when there is a width difference

SVA-261