### PR TITLE
fix(sidebar): remove bottom orientation

### DIFF
--- a/app/assets/stylesheets/custom.css
+++ b/app/assets/stylesheets/custom.css
@@ -67,8 +67,8 @@ body .table {
 
 body .navbar-nav.sidebar {
   background-color: #11223f;
-  bottom: 0;
   left: 0;
+  min-height: 100%;
   position: absolute;
   top: 0;
   z-index: 2;


### PR DESCRIPTION
- when content was smaller than sidebar, the
bar got cut off
- therefore use min-height instead of bottom
orientation

SVA-334

Old:

![Bildschirmfoto 2021-10-14 um 09 12 17](https://user-images.githubusercontent.com/61157877/137269589-84273de9-0573-4236-afbf-2a0c15656bf9.png)


New

![Bildschirmfoto 2021-10-14 um 09 10 12](https://user-images.githubusercontent.com/61157877/137269384-79d5a089-c344-41a5-bd36-d4534f3d5276.png)
:
