### PR TITLE
Update records instead of deleting and creating

### DIFF
--- a/app/controllers/constructions_controller.rb
+++ b/app/controllers/constructions_controller.rb
@@ -80,10 +80,13 @@ class ConstructionsController < ApplicationController
     GRAPHQL
 
     @construction = results.data.generic_item
+  rescue Graphlient::Errors::GraphQLError
+    flash[:error] = "Die angeforderte Ressource ist leider nicht verfügbar"
+    redirect_to constructions_path
   end
 
   def create
-    query = create_params
+    query = create_or_update_mutation
     begin
       results = @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
@@ -98,41 +101,18 @@ class ConstructionsController < ApplicationController
   end
 
   def update
-    old_id = params[:id]
-    query = create_params
-    logger.warn(query)
+    construction_id = params[:id]
+
+    query = create_or_update_mutation(true)
+    # logger.warn(query)
 
     begin
-      results = @smart_village.query query
+      @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
       flash[:error] = e.errors.messages["data"].to_s
-      redirect_to edit_construction_path(old_id)
-      return
     end
 
-    new_id = results.data.create_generic_item.id
-
-    if new_id.present? && new_id != old_id
-      # Nach dem Erstellen des neuen Datensatzes wird der alte gelöscht
-
-      destroy_results = @smart_village.query <<~GRAPHQL
-        mutation {
-          destroyRecord(
-            id: #{old_id},
-            recordType: "GenericItem"
-          ) {
-            id
-            status
-            statusCode
-          }
-        }
-      GRAPHQL
-
-      redirect_to edit_construction_path(new_id)
-    else
-      flash[:error] = "Fehler: #{results.errors.inspect}"
-      redirect_to edit_construction_path(old_id)
-    end
+    redirect_to edit_construction_path(construction_id)
   end
 
   def destroy
@@ -159,6 +139,10 @@ class ConstructionsController < ApplicationController
 
   private
 
+    def construction_params
+      params.require(:construction).permit!
+    end
+
     def new_generic_item
       OpenStruct.new(
         generic_type: "ConstructionSite",
@@ -168,10 +152,10 @@ class ConstructionsController < ApplicationController
       )
     end
 
-    def create_params
-      @construction_params = params.require(:construction).permit!
+    def create_or_update_mutation(update = false)
+      @construction_params = construction_params
       convert_params_for_graphql
-      Converter::Base.new.build_mutation("createGenericItem", @construction_params)
+      Converter::Base.new.build_mutation("createGenericItem", @construction_params, update)
     end
 
     def convert_params_for_graphql

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -135,7 +135,7 @@ class NewsItemsController < ApplicationController
       redirect_to new_news_item_path and return
     end
 
-    query = create_params
+    query = create_or_update_mutation
     begin
       results = @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
@@ -150,47 +150,23 @@ class NewsItemsController < ApplicationController
   end
 
   def update
-    old_id = params[:id]
+    news_id = params[:id]
 
     unless category_present?(news_item_params)
       flash[:error] = "Bitte eine Kategorie auswählen"
-      redirect_to edit_news_item_path(old_id) and return
+      redirect_to edit_news_item_path(news_id) and return
     end
 
-    query = create_params
-    logger.warn(query)
+    query = create_or_update_mutation(true)
+    # logger.warn(query)
 
     begin
-      results = @smart_village.query query
+      @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
       flash[:error] = e.errors.messages["data"].to_s
-      redirect_to edit_news_item_path(old_id)
-      return
     end
 
-    new_id = results.data.create_news_item.id
-
-    if new_id.present? && new_id != old_id
-      # Nach dem Erstellen des neuen Datensatzes wird der alte gelöscht
-
-      destroy_results = @smart_village.query <<~GRAPHQL
-        mutation {
-          destroyRecord(
-            id: #{old_id},
-            recordType: "NewsItem"
-          ) {
-            id
-            status
-            statusCode
-          }
-        }
-      GRAPHQL
-
-      redirect_to edit_news_item_path(new_id)
-    else
-      flash[:error] = "Fehler: #{results.errors.inspect}"
-      redirect_to edit_news_item_path(old_id)
-    end
+    redirect_to edit_news_item_path(news_id)
   end
 
   def destroy
@@ -229,10 +205,10 @@ class NewsItemsController < ApplicationController
       )
     end
 
-    def create_params
+    def create_or_update_mutation(update = false)
       @news_item_params = news_item_params
       convert_params_for_graphql
-      Converter::Base.new.build_mutation("createNewsItem", @news_item_params)
+      Converter::Base.new.build_mutation("createNewsItem", @news_item_params, update)
     end
 
     def convert_params_for_graphql

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -124,6 +124,9 @@ class NewsItemsController < ApplicationController
     @news_item = results.data.news_item
 
     redirect_to news_items_path if @news_item.push_notifications_sent_at.present?
+  rescue Graphlient::Errors::GraphQLError
+    flash[:error] = "Die angeforderte Ressource ist leider nicht verfügbar"
+    redirect_to news_items_path
   end
 
   def create

--- a/app/controllers/offers_controller.rb
+++ b/app/controllers/offers_controller.rb
@@ -92,10 +92,13 @@ class OffersController < ApplicationController
     GRAPHQL
 
     @offer = results.data.generic_item
+  rescue Graphlient::Errors::GraphQLError
+    flash[:error] = "Die angeforderte Ressource ist leider nicht verfügbar"
+    redirect_to offers_path
   end
 
   def create
-    query = create_params
+    query = create_or_update_mutation
     begin
       results = @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
@@ -110,41 +113,18 @@ class OffersController < ApplicationController
   end
 
   def update
-    old_id = params[:id]
-    query = create_params
-    logger.warn(query)
+    offer_id = params[:id]
+
+    query = create_or_update_mutation(true)
+    # logger.warn(query)
 
     begin
-      results = @smart_village.query query
+      @smart_village.query query
     rescue Graphlient::Errors::GraphQLError => e
       flash[:error] = e.errors.messages["data"].to_s
-      redirect_to edit_offer_path(old_id)
-      return
     end
 
-    new_id = results.data.create_generic_item.id
-
-    if new_id.present? && new_id != old_id
-      # Nach dem Erstellen des neuen Datensatzes wird der alte gelöscht
-
-      destroy_results = @smart_village.query <<~GRAPHQL
-        mutation {
-          destroyRecord(
-            id: #{old_id},
-            recordType: "GenericItem"
-          ) {
-            id
-            status
-            statusCode
-          }
-        }
-      GRAPHQL
-
-      redirect_to edit_offer_path(new_id)
-    else
-      flash[:error] = "Fehler: #{results.errors.inspect}"
-      redirect_to edit_offer_path(old_id)
-    end
+    redirect_to edit_offer_path(offer_id)
   end
 
   def destroy
@@ -171,6 +151,10 @@ class OffersController < ApplicationController
 
   private
 
+    def offer_params
+      params.require(:offer).permit!
+    end
+
     def new_generic_item
       OpenStruct.new(
         generic_type: "Offer",
@@ -185,10 +169,10 @@ class OffersController < ApplicationController
       )
     end
 
-    def create_params
-      @offer_params = params.require(:offer).permit!
+    def create_or_update_mutation(update = false)
+      @offer_params = offer_params
       convert_params_for_graphql
-      Converter::Base.new.build_mutation("createGenericItem", @offer_params)
+      Converter::Base.new.build_mutation("createGenericItem", @offer_params, update)
     end
 
     def convert_params_for_graphql

--- a/app/services/converter/base.rb
+++ b/app/services/converter/base.rb
@@ -1,7 +1,7 @@
 module Converter
   class Base
-    def build_mutation(name, data)
-      data = cleanup(data) unless name.downcase.include?("update")
+    def build_mutation(name, data, update = false)
+      data = cleanup(data) unless name.downcase.include?("update") || update
       data = convert_to_json(data)
       data = convert_keys_to_camelcase(data)
       data = remove_quotes_from_keys(data)

--- a/app/views/constructions/_form.html.erb
+++ b/app/views/constructions/_form.html.erb
@@ -1,4 +1,5 @@
 <%= fields_for :construction, construction do |f| %>
+  <%= hidden_field_tag "construction[id]", f.object.id if f.object.id.present? %>
   <%= hidden_field_tag "construction[generic_type]", construction.generic_type %>
 
   <div class="row">

--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -1,4 +1,5 @@
 <%= fields_for :event, event do |f| %>
+  <%= hidden_field_tag "event[id]", f.object.id if f.object.id.present? %>
   <%= hidden_field_tag "event[category_name]", @event.category.name if @event.category.present? %>
 
   <div class="row">

--- a/app/views/jobs/_form.html.erb
+++ b/app/views/jobs/_form.html.erb
@@ -1,4 +1,5 @@
 <%= fields_for :job, job do |f| %>
+  <%= hidden_field_tag "job[id]", f.object.id if f.object.id.present? %>
   <%= hidden_field_tag "job[generic_type]", @job.generic_type %>
 
   <div class="row">

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -1,4 +1,6 @@
 <%= fields_for :news_item, news_item do |f| %>
+  <%= hidden_field_tag "news_item[id]", f.object.id if f.object.id.present? %>
+
   <!-- NOTE: Wird erstmal nicht benötigt
     <div class="row">
       <div class="col">

--- a/app/views/offers/_form.html.erb
+++ b/app/views/offers/_form.html.erb
@@ -1,4 +1,5 @@
 <%= fields_for :offer, offer do |f| %>
+  <%= hidden_field_tag "offer[id]", f.object.id if f.object.id.present? %>
   <%= hidden_field_tag "offer[generic_type]", @offer.generic_type %>
 
   <div class="row">

--- a/app/views/point_of_interests/_form.html.erb
+++ b/app/views/point_of_interests/_form.html.erb
@@ -1,4 +1,6 @@
 <%= fields_for :point_of_interest, point_of_interest do |f| %>
+  <%= hidden_field_tag "point_of_interest[id]", f.object.id if f.object.id.present? %>
+
   <div class="row">
     <div class="col">
       <div class="form-group">

--- a/app/views/tours/_form.html.erb
+++ b/app/views/tours/_form.html.erb
@@ -1,4 +1,6 @@
 <%= fields_for :tour, tour do |f| %>
+  <%= hidden_field_tag "tour[id]", f.object.id if f.object.id.present? %>
+
   <div class="row">
     <div class="col">
       <div class="form-group">


### PR DESCRIPTION
based on main-server PR: https://github.com/ikuseiGmbH/smart-village-app-mainserver/pull/210

- adjusted all resources
- in the past often outdated or wrong ids were used in calls to edit pages which failed with an error
- now we rescue graphql errors and redirect to the index pages instead with an flash error message

![Bildschirmfoto 2021-11-18 um 18 48 04](https://user-images.githubusercontent.com/1942953/142469350-8f48b3ce-2a85-49a2-9606-c7623f68b014.png)

SVA-176