### PR TITLE
feat(surveys): use text area for response options

### DIFF
--- a/app/views/surveys/_form.html.erb
+++ b/app/views/surveys/_form.html.erb
@@ -65,7 +65,7 @@
         Stimmen abgegeben wurden.
       </p>
 
-      <p><small>(min. 2, max. 10, Zeichenlänge max. 150, in deutsch und polnisch)</small></p>
+      <p><small>(min. 2, max. 10, HTML möglich, in deutsch und polnisch)</small></p>
 
       <%= render partial: "surveys/form_partials/response_options_form", locals: { survey: survey, form: f  } %>
     </div>

--- a/app/views/surveys/form_partials/_response_options_form.html.erb
+++ b/app/views/surveys/form_partials/_response_options_form.html.erb
@@ -14,13 +14,13 @@
           <div class="col-12 col-sm-6">
             <div class="form-group">
               <label for="description"><%= index + 1 %>. Antwortmöglichkeit (deutsch)<%= " *" if [0, 1].include?(index) %></label>
-              <%= fro.text_field :title_de, name: "survey[response_options][#{index}][title][de]", class: "form-control", maxlength: "150", required: [0, 1].include?(index) %>
+              <%= fro.text_area :title_de, name: "survey[response_options][#{index}][title][de]", class: "form-control", rows: 2, required: [0, 1].include?(index) %>
             </div>
           </div>
           <div class="col-12 col-sm-6">
             <div class="form-group">
               <label for="description"><%= index + 1 %>. Antwortmöglichkeit (polnisch)</label>
-              <%= fro.text_field :title_pl, name: "survey[response_options][#{index}][title][pl]", class: "form-control", maxlength: "150" %>
+              <%= fro.text_area :title_pl, name: "survey[response_options][#{index}][title][pl]", class: "form-control", rows: 2 %>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- to be able to use html contents reasonable

SVA-364

|before|after|
|---|---|
|![Bildschirmfoto 2021-11-26 um 16 34 58](https://user-images.githubusercontent.com/1942953/143604180-b6e39297-ff07-454f-b837-636b29434568.png)|![Bildschirmfoto 2021-11-26 um 16 36 49](https://user-images.githubusercontent.com/1942953/143604192-32b28a30-2b67-434c-9760-7b063777d040.png)|