### PR TITLE
fix(opening hours): save unchecked check box

### DIFF
--- a/app/controllers/point_of_interests_controller.rb
+++ b/app/controllers/point_of_interests_controller.rb
@@ -277,6 +277,12 @@ class PointOfInterestsController < ApplicationController
         @point_of_interest_params["opening_hours"].each do |_key, opening_hour|
           next if opening_hour.blank?
 
+          # it is needed to cast "false" to boolean here in order to pass GraphQL server validations
+          # => Graphlient::Errors::ClientError (Argument 'open' on InputObject 'OpeningHourInput' has an invalid value. Expected type 'Boolean'.)
+          # somehow magic happens for check_box value "true" and it is not needed
+          if opening_hour[:open].present? && opening_hour[:open] == "false"
+            opening_hour[:open] = false
+          end
           opening_hours << opening_hour if nested_values?(opening_hour.to_h).include?(true)
         end
         @point_of_interest_params["opening_hours"] = opening_hours

--- a/app/views/shared/partials/_opening_hours_form.html.erb
+++ b/app/views/shared/partials/_opening_hours_form.html.erb
@@ -87,7 +87,17 @@
             <div class="row">
               <div class="col-12 col-sm-6">
                 <div class="form-group">
-                  <%= foh.check_box :open, { checked: true }, true, false %>
+                  <%= foh.hidden_field(
+                        :open,
+                        value: false,
+                        id: nil
+                      ) %>
+                  <%= foh.check_box(
+                        :open,
+                        { checked: foh.object.open.nil? ? true : foh.object.open },
+                        true,
+                        false
+                      ) %>
                   <%= foh.label :open, "geöffnet?" %>
                 </div>
               </div>


### PR DESCRIPTION
- added hidden field for `:open` check box, as rails
  does not render it automatically with the `.check_box`
  when passed `false` as last param (unchecked value)
- cast `"false"` to boolean in parameters being sent to the
  server, as this does not happen automatically and produces
  errors
  - somehow magic happens for check_box value "true" and it
    is not needed
- updated default check box value to respect to objects value
  if given

SVA-434

---

![Bildschirmfoto am 2022-02-04 um 11 39 03-fullpage](https://user-images.githubusercontent.com/1942953/152515138-b5d9bd5f-25cf-44ea-9cd2-462366bfe2e7.png)