### PR TITLE
feat: hide caption text of media contents

### DIFF
--- a/app/views/shared/partials/_media_contents_form.html.erb
+++ b/app/views/shared/partials/_media_contents_form.html.erb
@@ -48,7 +48,7 @@
               </div>
             <% end %>
 
-            <div class="row">
+            <div class="row" hidden>
               <div class="col">
                 <div class="form-group">
                   <label for="description">Bildunterschrift</label>


### PR DESCRIPTION
- set the block for caption text to hidden, as there is no application
  that renders the caption text
- did not remove it entirely, to ensure that possible data will not be removed
  when saving media contents
  - values will still be read and written with the form

SVA-494

![Bildschirmfoto 2022-03-25 um 09 34 26](https://user-images.githubusercontent.com/1942953/160085988-7eeb9f79-d8fe-4307-8900-48f72691d3be.png)