### PR TITLE
WasteCalendar: Add missing version to receive JSON instead of string

### DIFF
--- a/app/controllers/waste_calendar_controller.rb
+++ b/app/controllers/waste_calendar_controller.rb
@@ -9,7 +9,7 @@ class WasteCalendarController < ApplicationController
   def index
     results = @smart_village.query <<~GRAPHQL
       query {
-        publicJsonFile(name: "wasteTypes") {
+        publicJsonFile(name: "wasteTypes", version: "1.0.0") {
           content
         }
       }
@@ -42,7 +42,7 @@ class WasteCalendarController < ApplicationController
   def create
     results = @smart_village.query <<~GRAPHQL
       query {
-        publicJsonFile(name: "wasteTypes") {
+        publicJsonFile(name: "wasteTypes", version: "1.0.0") {
           content
         }
       }


### PR DESCRIPTION
`query { publicJsonFile(name: "wasteTypes") {content} ` Liefert ein String statt einem JSOn Datensatz ohne den Zusatz der Version

SVA-535