### PR TITLE
fix(fileupload): after removing file sections

### DIFF
--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -24,10 +24,11 @@ require('../partials/_nested_lunch_form');
 // map in forms
 require('../partials/_leaflet_map');
 
+// fileupload in forms
+require('../partials/_fileupload');
+
 // ckeditor custom build
 require('../ckeditor');
-
-require('./fileupload')
 
 // Uncomment to copy all static images under ../images to the output folder and reference
 // them with the image_pack_tag helper in views (e.g <%= image_pack_tag 'rails.png' %>)

--- a/app/javascript/partials/_fileupload.js
+++ b/app/javascript/partials/_fileupload.js
@@ -1,4 +1,4 @@
-const axios = require('axios')
+const axios = require('axios');
 
 async function getSignedUrl(filename) {
   let response = await axios.get('/minio/signed_url.json?filename=' + filename);
@@ -6,7 +6,6 @@ async function getSignedUrl(filename) {
 }
 
 async function upload(file, signedUrl, formIndex) {
-
   $('.upload-progress-' + formIndex).show('slow');
 
   await axios.put(signedUrl, file, {
@@ -18,7 +17,7 @@ async function upload(file, signedUrl, formIndex) {
       $('.upload-progress-bar-' + formIndex)
         .attr('aria-valuenow', percentCompleted)
         .css('width', percentCompleted + '%');
-    },
+    }
   });
 }
 
@@ -38,7 +37,9 @@ async function handleFileChange(e) {
     $('.image-preview-wrapper-' + formIndex).show('slow');
 
     // Put the url of the uploaded file into the url input make it readonly
-    $(e.target).closest('.nested-medium-form').find('.media-content-url')
+    $(e.target)
+      .closest('.nested-medium-form')
+      .find('.media-content-url')
       .val(fileUrl)
       .attr('readonly', true);
   } catch (e) {
@@ -49,12 +50,14 @@ async function handleFileChange(e) {
 // Saving this globally, because we need to rebind events
 // when a new nested form is added
 window.bindFileUploadEvents = () => {
-  $('.upload-toggle').off().on('click', (e) => {
-    const formIndex = e.target.dataset.index;
-    $('.file-input-' + formIndex).click();
-  });
+  $('.upload-toggle')
+    .off()
+    .on('click', (e) => {
+      const formIndex = e.target.dataset.index;
+      $('.file-input-' + formIndex).click();
+    });
   $('.file-input').off().on('change', handleFileChange);
-}
+};
 
 $(() => {
   window.bindFileUploadEvents();

--- a/app/javascript/partials/_nested_forms.js
+++ b/app/javascript/partials/_nested_forms.js
@@ -89,12 +89,6 @@ $(function () {
       $container.children('.nested-medium-form').removeClass('d-none');
     },
     afterAddForm: function (_, $form) {
-      // If we only have one nested media form, we don't have to do anything
-      // becasue the index of 0 is already the right one
-      if ($('.nested-medium-form').length === 1) {
-        return;
-      }
-
       // Increment the index on all elements of the new form by 100
       let oldFormIndex = nestedMediaFormCount - 1;
       let formIndex = $('.nested-medium-form').length - 1;

--- a/app/javascript/partials/_nested_forms.js
+++ b/app/javascript/partials/_nested_forms.js
@@ -7,7 +7,7 @@ export const defaultNestedFormsOptions = {
 };
 
 /* eslint-disable func-names */
-$(function() {
+$(function () {
   $('#nested-categories').nestedForm({
     forms: '.nested-category-form',
     adder: '#nested-add-category',
@@ -75,7 +75,6 @@ $(function() {
     }
   });
 
-
   // We need to know the amount of forms at DOM load to know which classes we have to fix,
   // see below in afterAddForm callback
   const nestedMediaFormCount = $('.nested-medium-form').length;
@@ -89,8 +88,7 @@ $(function() {
     beforeAddForm: ($container) => {
       $container.children('.nested-medium-form').removeClass('d-none');
     },
-    afterAddForm: function(_, $form) {
-
+    afterAddForm: function (_, $form) {
       // If we only have one nested media form, we don't have to do anything
       // becasue the index of 0 is already the right one
       if ($('.nested-medium-form').length === 1) {
@@ -111,7 +109,7 @@ $(function() {
         'upload-progress-bar',
         'image-preview-wrapper',
         'image-preview'
-      ]
+      ];
 
       classNamesToFix.forEach((className) => {
         let $el = $form.find('.' + className);

--- a/app/views/shared/partials/_media_contents_form.html.erb
+++ b/app/views/shared/partials/_media_contents_form.html.erb
@@ -18,7 +18,6 @@
           </div>
 
           <div class="card-body">
-
             <%= render partial: "shared/partials/fileupload", locals: { index: index } %>
 
             <%= fmc.fields_for :source_url, media_content.source_url do |fu| %>


### PR DESCRIPTION
- moved fileupload.js to partials folder as `packs` should contain just auto generated files and this js is used for the `_fileupload` erb partial
- auto linted files
- removed code because after deleting all existing file sections and starting over again with adding one, functionality was not bind due to that early return
  - it was only working again after adding at least a second file section to have a length larger than 1 to bypass the condition

SVA-626