### PR TITLE
fix: Add empty address to edit form

### DIFF
--- a/app/views/events/_form.html.erb
+++ b/app/views/events/_form.html.erb
@@ -72,7 +72,8 @@
     </div>
   </div>
 
-  <% event.addresses.each_with_index do |address, index| %>
+  <% addresses_to_render = event.addresses.presence || [OpenStruct.new] %>
+  <% addresses_to_render.each_with_index do |address, index| %>
     <%= f.fields_for "addresses[#{index}]", address do |fadd| %>
       <%= render(
             partial: "shared/partials/address_form",


### PR DESCRIPTION
Adds an OpenStruct if there is no address in graphql response to get the form rendered.

SVA-495

![Bildschirmfoto 2022-07-12 um 14 07 47](https://user-images.githubusercontent.com/90779/178486653-026d8d09-7f04-4f8d-96ee-fea719aaf896.png)
