### PR TITLE
feat(tour): show tour routes in edit form

### DIFF
--- a/app/controllers/tours_controller.rb
+++ b/app/controllers/tours_controller.rb
@@ -114,6 +114,10 @@ class ToursController < ApplicationController
           dataProvider {
             name
           }
+          geometryTourData {
+            latitude
+            longitude
+          }
         }
       }
     GRAPHQL

--- a/app/javascript/partials/_leaflet_map.js
+++ b/app/javascript/partials/_leaflet_map.js
@@ -1,19 +1,30 @@
-var L = require('leaflet/dist/leaflet');
-var LGH = require('leaflet-gesture-handling/dist/leaflet-gesture-handling');
+const L = require('leaflet/dist/leaflet');
+const LGH = require('leaflet-gesture-handling/dist/leaflet-gesture-handling');
 
-var CENTER_OF_GERMANY = [51.3127114, 9.4797461];
-var DEFAULT_ZOOM_LEVEL = 6;
+const CENTER_OF_GERMANY = [51.3127114, 9.4797461];
+const DEFAULT_ZOOM_LEVEL = 6;
+const ICON = L.icon({
+  iconUrl: '/marker.svg',
+  iconSize: [30, 30],
+  iconAnchor: [15, 30]
+});
+const ATTRIBUTION = {
+  attribution:
+    '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+};
+
+L.Map.addInitHook('addHandler', 'gestureHandling', LGH.GestureHandling);
 
 function initLeafletMap(id) {
-  var $parentRow = $('#' + id)
+  const $parentRow = $('#' + id)
     .parent()
     .parent()
     .parent();
-  var $geoLocationLatitude = $parentRow.find('[id$="geo_location_latitude"]');
-  var $geoLocationLongitude = $parentRow.find('[id$="geo_location_longitude"]');
+  const $geoLocationLatitude = $parentRow.find('[id$="geo_location_latitude"]');
+  const $geoLocationLongitude = $parentRow.find('[id$="geo_location_longitude"]');
 
-  var center = CENTER_OF_GERMANY;
-  var zoom = DEFAULT_ZOOM_LEVEL;
+  let center = CENTER_OF_GERMANY;
+  let zoom = DEFAULT_ZOOM_LEVEL;
   if ($geoLocationLatitude.val() && $geoLocationLongitude.val()) {
     // Set center to eventually existing lat lng values
     center = [$geoLocationLatitude.val(), $geoLocationLongitude.val()];
@@ -21,30 +32,22 @@ function initLeafletMap(id) {
     zoom = 13;
   }
 
-  L.Map.addInitHook('addHandler', 'gestureHandling', LGH.GestureHandling);
-
-  var map = L.map(id, {
+  const map = L.map(id, {
     minZoom: 3,
     zoom,
     center,
     gestureHandling: true
   });
 
-  var icon = L.icon({
-    iconUrl: '/marker.svg',
-    iconSize: [30, 30],
-    iconAnchor: [15, 30]
-  });
-
-  var marker;
+  let marker;
   if ($geoLocationLatitude.val() && $geoLocationLongitude.val()) {
     // Set marker for eventually existing lat lng values
-    marker = L.marker(center, { icon: icon }).addTo(map);
+    marker = L.marker(center, { icon: ICON }).addTo(map);
   }
 
   map.on('click', function (e) {
-    var lat = e.latlng.lat;
-    var lng = e.latlng.lng;
+    const lat = e.latlng.lat;
+    const lng = e.latlng.lng;
 
     // Clear existing marker before setting a new one
     if (marker != undefined) {
@@ -52,23 +55,70 @@ function initLeafletMap(id) {
     }
 
     // Set the new marker on clicked position
-    marker = L.marker([lat, lng], { icon: icon }).addTo(map);
+    marker = L.marker([lat, lng], { icon: ICON }).addTo(map);
 
     $geoLocationLatitude.val(lat);
     $geoLocationLongitude.val(lng);
   });
 
-  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-    attribution:
-      '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-  }).addTo(map);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', ATTRIBUTION).addTo(map);
+}
+
+function initLeafletMapTour(id) {
+  let center = CENTER_OF_GERMANY;
+  let zoom = DEFAULT_ZOOM_LEVEL;
+
+  const tourCoordinates = JSON.parse(
+    $('#' + id)
+      .siblings('[hidden="tour-coordinates"]')
+      .text()
+  );
+
+  if (tourCoordinates?.length) {
+    const firstTourCoordinate = tourCoordinates[0];
+    center = [firstTourCoordinate.lat, firstTourCoordinate.lng];
+    zoom = 11;
+
+    const map = L.map(id, {
+      minZoom: 3,
+      zoom,
+      center,
+      gestureHandling: true
+    });
+
+    L.marker([firstTourCoordinate.lat, firstTourCoordinate.lng], { icon: ICON }).addTo(map);
+
+    L.polyline(tourCoordinates, {
+      color: '#11223f',
+      weight: 5,
+      opacity: 0.75,
+      smoothFactor: 1
+    }).addTo(map);
+
+    const lastTourCoordinate = tourCoordinates[tourCoordinates.length - 1];
+    L.marker([lastTourCoordinate.lat, lastTourCoordinate.lng], { icon: ICON }).addTo(map);
+
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', ATTRIBUTION).addTo(map);
+  }
 }
 
 $(function () {
-  // Check if map exists on page after a short timeout being rendered and init maps in a loop
+  // Check if map container exists on page per interval and init maps in a loop when found
+  const initLeafletMapInterval = setInterval(function () {
+    if ($('.leafletMap').length) {
+      clearInterval(initLeafletMapInterval);
+
+      $('.leafletMapTour').each(function () {
+        initLeafletMapTour(this.id);
+      });
+
+      $('.leafletMap:not(.leafletMapTour)').each(function () {
+        initLeafletMap(this.id);
+      });
+    }
+  }, 100);
+
   setTimeout(function () {
-    $('.leafletMap').each(function () {
-      initLeafletMap(this.id);
-    });
-  }, 500);
+    clearInterval(initLeafletMapInterval);
+  }, 4000);
 });

--- a/app/views/tours/_form.html.erb
+++ b/app/views/tours/_form.html.erb
@@ -48,6 +48,15 @@
     </div>
   </div>
 
+  <div class="row">
+    <div class="col">
+      <div class="form-group">
+        <label for="description">Tourenverlauf</label>
+        <%= render partial: "tours/form_partials/tour_path", locals: { record: tour, form: f }  %>
+      </div>
+    </div>
+  </div>
+
   <hr />
 
   <div class="row">

--- a/app/views/tours/form_partials/_tour_path.html.erb
+++ b/app/views/tours/form_partials/_tour_path.html.erb
@@ -1,0 +1,11 @@
+<% geometry_tour_data ||= record.try(:geometry_tour_data) %>
+<% if geometry_tour_data.present? %>
+  <% tour_coordinates = geometry_tour_data.map { |gtd| { lng: gtd.longitude, lat: gtd.latitude} } %>
+<% end %>
+
+<% if tour_coordinates %>
+  <div class="form-group">
+    <span hidden="tour-coordinates"><%= tour_coordinates.to_json %></span>
+    <div id="leafletMapTour" class="leafletMap leafletMapTour"></div>
+  </div>
+<% end %>


### PR DESCRIPTION
This is the first prerequisite for creating and editing AR for tours. In order to place, create and edit AR entries we show the tour route with start and end point.

<img width="1084" alt="Bildschirmfoto 2022-07-25 um 19 22 52" src="https://user-images.githubusercontent.com/1942953/180837476-cc4b3def-94c9-420b-bab4-6a9e20221903.png">

SVA-572